### PR TITLE
Update RestClient.php to support php 8

### DIFF
--- a/src/rest/RestClient.php
+++ b/src/rest/RestClient.php
@@ -207,7 +207,7 @@ class RestClient {
    * @return \telesign\sdk\rest\Response The RestClient Response object
    */
   protected function execute ($method_name, $resource, $fields = [], $date = null, $nonce = null) {
-    $url_encoded_fields = http_build_query($fields, null, "&");
+    $url_encoded_fields = http_build_query($fields, '', "&");
 
     $headers = $this->generateTelesignHeaders(
       $this->customer_id,


### PR DESCRIPTION
in php 8 

Fatal error: Uncaught ErrorException: http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated in /home/doublelist.com/public_html/vendor/telesign/telesign/src/rest/RestClient.php:210